### PR TITLE
Add ScriptCS C# Responder

### DIFF
--- a/responders/csharp/packages.config
+++ b/responders/csharp/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="RabbitMQ.Client" version="3.3.2" targetFramework="net30" />
+</packages>

--- a/responders/csharp/responder.csx
+++ b/responders/csharp/responder.csx
@@ -1,0 +1,33 @@
+using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
+
+var routeId = "GET/_/csharp/hello";
+var factory = new ConnectionFactory() { HostName = "localhost", UserName = "guest", Password = "guest" };
+using (var connection = factory.CreateConnection())
+{
+  using (var channel = connection.CreateModel())
+  {
+    channel.QueueDeclare(routeId, true, false, true, null);
+    var consumer = new QueueingBasicConsumer(channel);
+    channel.BasicConsume(routeId, false, consumer);
+
+    Console.Write("[Responder ready]");
+
+    // while (true) makes mono freak out, so I'm applying some hackery
+    var i = 0;
+    while (i < 1)
+    {
+      var ea = (BasicDeliverEventArgs)consumer.Queue.Dequeue();
+      var props = ea.BasicProperties;
+
+      Console.WriteLine(" [x] Received {0}", Encoding.UTF8.GetString(ea.Body));
+
+      channel.BasicAck(ea.DeliveryTag, false);
+
+      var json = @"[200, { ""Content-Type"": ""text/html"" }, ""<h1>Hello C#!</h1>""]";
+
+      channel.BasicPublish("", props.ReplyTo, null, Encoding.UTF8.GetBytes(json));
+      Console.WriteLine(" [x] Sent {0}", json);
+    }
+  }
+}


### PR DESCRIPTION
Here's a ScriptCS C# responder (I haven't tested it in this pull request, but it works with my Docker setup).

If you are new to ScriptCS on Mono, you can do this (assuming mono is installed):
1. `git clone https://github.com/scriptcs/scriptcs.git && cd scriptcs/ && ./build.sh`
2. `cd src/ScriptCs/bin/Release/`
3. `mono scriptcs.exe /path/to/responder.csx`

Note: On step 3, it should auto-install the nuget packages and then run, but if it doesn't, you can do `mono scriptcs.exe -install RabbitMQ.Client` and place the `packages/` directory in the `responders/charp/` path. I think you can probably make a bash script to do the `mono scriptcs.exe` stuff and place it in `.foreman` / `Procfile`. Please let me know if you have any questions.
