### PR TITLE
Pull RabbitMQ connection details from the environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Once you have installed RabbitMQ, you can start up the queue with this:
 
     rabbitmq-server
 
+Polyglot will look for a RabbitMQ server connection URL in the environment variable `AMQP_HOST`, and if not found will default to `amqp://guest:guest@localhost:5672/`.
 
 ### Responder
 

--- a/polyglot.go
+++ b/polyglot.go
@@ -10,6 +10,7 @@ import (
   "fmt"
   "strings"
   "net/http"
+  "os"
   // "reflect"
 )
 
@@ -34,7 +35,12 @@ func process(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
   // fmt.Println(routeId)
   failOnError(err, "Failed to marshal the request")  
   
-  conn, err := amqp.Dial("amqp://guest:guest@localhost:5672/")
+  amqp_host := os.Getenv("AMQP_HOST")
+  if amqp_host == "" {
+    amqp_host = "amqp://guest:guest@localhost:5672/"
+  }
+  
+  conn, err := amqp.Dial(amqp_host)
   failOnError(err, "Failed to connect to RabbitMQ")
   defer conn.Close()
 


### PR DESCRIPTION
This is untested (I can't do this stuff from where I am), but I believe should work.

The RabbitMQ connection details should be pulled from the environment so it can work with arbitrary connections.
